### PR TITLE
Scope the Client api for both db-servers inside a nested .Client module

### DIFF
--- a/lib/my_db.ex
+++ b/lib/my_db.ex
@@ -1,7 +1,7 @@
 defmodule MyDb do
   @moduledoc """
   MyDb module (lib/my_db.ex) is intended to be an API module to a database. Imple-
-  ment its functions by forwarding the calls to the DbServer module. The API should
+  ment its functions by forwarding the calls to the DbClient module. The API should
   be as follows:
 
   MyDb.start() → :ok
@@ -11,39 +11,39 @@ defmodule MyDb do
   MyDb.match(element) → {:ok, [key1, ..., keyn]}
   """
 
-  alias MyDb.DbGenserver, as: Server
+  alias MyDb.DbGenserver.Client, as: Client
 
   @doc "Start the database server"
   def start(%{backend: backend}) do
-    Server.start(backend)
+    Client.start(backend)
   end
 
   def start do
-    Server.start()
+    Client.start()
   end
 
   @doc "Stop the database server"
   def stop do
-    Server.stop()
+    Client.stop()
   end
 
   @doc "Write a key-value pair into the database"
   def write(key, value) do
-    Server.write(key, value)
+    Client.write(key, value)
   end
 
   @doc "Delete a key-value pair from the database (given the key)"
   def delete(key) do
-    Server.delete(key)
+    Client.delete(key)
   end
 
   @doc "Read the value from the database for a given key"
   def read(key) do
-    Server.read(key)
+    Client.read(key)
   end
 
   @doc "Find all keys that have a specified value in the database"
   def match(value) do
-    Server.match(value)
+    Client.match(value)
   end
 end

--- a/lib/my_db/db_genserver.ex
+++ b/lib/my_db/db_genserver.ex
@@ -5,48 +5,50 @@ defmodule MyDb.DbGenserver do
   implement a database server using Genserver
   """
 
-  ## Client API ---------------------------------------------------------------
+  defmodule Client do
+    @moduledoc "The methods used by the client to communicate with the server"
 
-  def start do
-    start(MyDb.Backends.MapDb)
-  end
+    def start do
+      start(MyDb.Backends.MapDb)
+    end
 
-  def start(backend) do
-    {:ok, _pid} = GenServer.start_link(MyDb.DbGenserver, backend, name: MyDb.DbGenserver)
-    :ok
-  end
+    def start(backend) do
+      {:ok, _pid} = GenServer.start_link(MyDb.DbGenserver, backend, name: MyDb.DbGenserver)
+      :ok
+    end
 
-  def stop do
-    pid = Process.whereis(MyDb.DbGenserver)
-    IO.puts("trying to stop #{inspect({MyDb.DbGenserver, :normal, 1_000})} (#{inspect(pid)})")
-    :ok = GenServer.stop(MyDb.DbGenserver, :normal, 1_000)
-    :ok
-  end
+    def stop do
+      pid = Process.whereis(MyDb.DbGenserver)
+      IO.puts("trying to stop #{inspect({MyDb.DbGenserver, :normal, 1_000})} (#{inspect(pid)})")
+      :ok = GenServer.stop(MyDb.DbGenserver, :normal, 1_000)
+      :ok
+    end
 
-  def write(key, value) do
-    GenServer.call(MyDb.DbGenserver, {:write, key, value})
-  end
+    def write(key, value) do
+      GenServer.call(MyDb.DbGenserver, {:write, key, value})
+    end
 
-  def delete(key) do
-    GenServer.call(MyDb.DbGenserver, {:delete, key})
-  end
+    def delete(key) do
+      GenServer.call(MyDb.DbGenserver, {:delete, key})
+    end
 
-  def read(key) do
-    GenServer.call(MyDb.DbGenserver, {:read, key})
-  end
+    def read(key) do
+      GenServer.call(MyDb.DbGenserver, {:read, key})
+    end
 
-  def match(value) do
-    GenServer.call(MyDb.DbGenserver, {:match, value})
-  end
+    def match(value) do
+      GenServer.call(MyDb.DbGenserver, {:match, value})
+    end
 
-  def write_async(key, value) do
-    GenServer.cast(MyDb.DbGenserver, {:write, key, value})
-    :ok
-  end
+    def write_async(key, value) do
+      GenServer.cast(MyDb.DbGenserver, {:write, key, value})
+      :ok
+    end
 
-  def delete_async(key) do
-    GenServer.cast(MyDb.DbGenserver, {:delete, key})
-    :ok
+    def delete_async(key) do
+      GenServer.cast(MyDb.DbGenserver, {:delete, key})
+      :ok
+    end
   end
 
   ## GenServer callbacks ------------------------------------------------------

--- a/lib/my_db/db_server.ex
+++ b/lib/my_db/db_server.ex
@@ -12,63 +12,58 @@ defmodule MyDb.DbServer do
   MyDb.match(element) → [key1, ..., keyn]
   """
 
-  @backends %{
-    map_db: MyDb.Backends.MapDb,
-    tree_db: MyDb.Backends.TreeDb,
-    list_db: MyDb.Backends.ListDb,
-    ets_db: MyDb.Backends.EtsDb,
-    struct_db: MyDb.Backends.StructDb
-  }
+  defmodule Client do
+    @moduledoc "The methods used by the client to communicate with the server"
 
-  def start do
-    start(:map_db)
-  end
+    def start do
+      start(MyDb.Backends.MapDb)
+    end
 
-  def start(backend_name) do
-    {:ok, backend} = Map.fetch(@backends, backend_name)
-    pid = spawn(MyDb.DbServer, :init, [backend])
-    Process.register(pid, MyDb.DbServer)
-    :ok
-  end
+    def start(backend) do
+      pid = spawn(MyDb.DbServer, :init, [backend])
+      Process.register(pid, MyDb.DbServer)
+      :ok
+    end
 
-  def stop() do
-    send(MyDb.DbServer, {:destroy})
-    :ok
-  end
+    def stop() do
+      send(MyDb.DbServer, {:destroy})
+      :ok
+    end
 
-  def write(key, value) do
-    call({:write, key, value})
-  end
+    def write(key, value) do
+      call({:write, key, value})
+    end
 
-  def delete(key) do
-    call({:delete, key})
-  end
+    def delete(key) do
+      call({:delete, key})
+    end
 
-  def read(key) do
-    call({:read, key})
-  end
+    def read(key) do
+      call({:read, key})
+    end
 
-  def match(value) do
-    call({:match, value})
-  end
+    def match(value) do
+      call({:match, value})
+    end
 
-  def records() do
-    call({:records})
-  end
+    def records() do
+      call({:records})
+    end
 
-  def lock() do
-    call({:lock})
-  end
+    def lock() do
+      call({:lock})
+    end
 
-  def unlock() do
-    call({:unlock})
-  end
+    def unlock() do
+      call({:unlock})
+    end
 
-  defp call(message) do
-    send(MyDb.DbServer, {:request, self(), message})
+    defp call(message) do
+      send(MyDb.DbServer, {:request, self(), message})
 
-    receive do
-      {:reply, reply} -> reply
+      receive do
+        {:reply, reply} -> reply
+      end
     end
   end
 

--- a/test/my_db/db_genserver_test.exs
+++ b/test/my_db/db_genserver_test.exs
@@ -1,50 +1,50 @@
 defmodule MyDb.DbGenserverTest do
-  alias MyDb.DbGenserver, as: Server
+  alias MyDb.DbGenserver.Client, as: Client
   alias MyDb.Backends.MapDb, as: MapDb
   use ExUnit.Case, async: false
 
-  describe "client API" do
-    setup do: Server.start(MapDb)
+  describe "MyDb.DbGenserver.Client" do
+    setup do: Client.start(MapDb)
 
     test "write/2" do
-      {:error, :instance} = Server.read(:a)
-      assert Server.write(:a, 1) == :ok
-      assert Server.read(:a) == {:ok, 1}
+      {:error, :instance} = Client.read(:a)
+      assert Client.write(:a, 1) == :ok
+      assert Client.read(:a) == {:ok, 1}
     end
 
     test "write_async/2" do
-      {:error, :instance} = Server.read(:a)
-      assert Server.write(:a, 1) == :ok
-      assert Server.read(:a) == {:ok, 1}
+      {:error, :instance} = Client.read(:a)
+      assert Client.write(:a, 1) == :ok
+      assert Client.read(:a) == {:ok, 1}
     end
 
     test "delete/1" do
-      :ok = Server.write(:a, 1)
-      {:ok, 1} = Server.read(:a)
-      assert Server.delete(:a) == :ok
-      assert Server.read(:a) == {:error, :instance}
+      :ok = Client.write(:a, 1)
+      {:ok, 1} = Client.read(:a)
+      assert Client.delete(:a) == :ok
+      assert Client.read(:a) == {:error, :instance}
     end
 
     test "delete_async/1" do
-      :ok = Server.write(:a, 1)
-      {:ok, 1} = Server.read(:a)
-      assert Server.delete_async(:a) == :ok
-      assert Server.read(:a) == {:error, :instance}
+      :ok = Client.write(:a, 1)
+      {:ok, 1} = Client.read(:a)
+      assert Client.delete_async(:a) == :ok
+      assert Client.read(:a) == {:error, :instance}
     end
 
     test "read/1" do
-      assert Server.read(:fooba) == {:error, :instance}
+      assert Client.read(:fooba) == {:error, :instance}
 
-      :ok = Server.write(:a, 1)
-      assert Server.read(:a) == {:ok, 1}
+      :ok = Client.write(:a, 1)
+      assert Client.read(:a) == {:ok, 1}
     end
 
     test "match/1" do
-      :ok = Server.write(:a, 1)
-      :ok = Server.write(:b, 2)
-      :ok = Server.write(:c, 1)
+      :ok = Client.write(:a, 1)
+      :ok = Client.write(:b, 2)
+      :ok = Client.write(:c, 1)
 
-      {:ok, matches} = Server.match(1)
+      {:ok, matches} = Client.match(1)
       assert Enum.sort(matches) == [:a, :c]
     end
   end

--- a/test/my_db/db_server_test.exs
+++ b/test/my_db/db_server_test.exs
@@ -1,138 +1,138 @@
 defmodule MyDb.DbServerTest do
-  alias MyDb.DbServer, as: Server
+  alias MyDb.DbServer.Client, as: Client
   use ExUnit.Case, async: false
   doctest MyDb.DbServer
 
   test "write/2" do
-    :ok = Server.start()
-    assert Server.read(:foo) == {:error, :instance}
-    assert Server.write(:foo, 5)
-    assert Server.read(:foo) == {:ok, 5}
-    :ok = Server.stop()
+    :ok = Client.start()
+    assert Client.read(:foo) == {:error, :instance}
+    assert Client.write(:foo, 5)
+    assert Client.read(:foo) == {:ok, 5}
+    :ok = Client.stop()
   end
 
   test "delete/1" do
-    :ok = Server.start()
-    Server.write(:foo, 5)
-    Server.write(:bar, 6)
+    :ok = Client.start()
+    Client.write(:foo, 5)
+    Client.write(:bar, 6)
 
-    assert Server.delete(:foo) == :ok
-    assert Server.read(:foo) == {:error, :instance}
-    assert Server.read(:bar) == {:ok, 6}
-    :ok = Server.stop()
+    assert Client.delete(:foo) == :ok
+    assert Client.read(:foo) == {:error, :instance}
+    assert Client.read(:bar) == {:ok, 6}
+    :ok = Client.stop()
   end
 
   test "read/1" do
-    :ok = Server.start()
-    Server.write(:foo, 5)
-    Server.write(:bar, 6)
+    :ok = Client.start()
+    Client.write(:foo, 5)
+    Client.write(:bar, 6)
 
-    assert Server.read(:foo) == {:ok, 5}
-    assert Server.read(:baz) == {:error, :instance}
-    :ok = Server.stop()
+    assert Client.read(:foo) == {:ok, 5}
+    assert Client.read(:baz) == {:error, :instance}
+    :ok = Client.stop()
   end
 
   test "match/1" do
-    :ok = Server.start()
-    Server.write(:foo, 5)
-    Server.write(:bar, 6)
-    Server.write(:bam, 5)
+    :ok = Client.start()
+    Client.write(:foo, 5)
+    Client.write(:bar, 6)
+    Client.write(:bam, 5)
 
-    {:ok, matches} = Server.match(5)
+    {:ok, matches} = Client.match(5)
     assert Enum.sort(matches) == [:bam, :foo]
-    assert Server.match(6) == {:ok, [:bar]}
-    :ok = Server.stop()
+    assert Client.match(6) == {:ok, [:bar]}
+    :ok = Client.stop()
   end
 
   describe "through the backends" do
     test ":list_db" do
-      :ok = Server.start(:list_db)
-      assert Server.write(:a, 1) == :ok
-      assert Server.write(:b, 2) == :ok
-      assert Server.write(:c, 1) == :ok
+      :ok = Client.start(MyDb.Backends.ListDb)
+      assert Client.write(:a, 1) == :ok
+      assert Client.write(:b, 2) == :ok
+      assert Client.write(:c, 1) == :ok
 
-      assert Server.read(:a) == {:ok, 1}
-      assert Server.read(:z) == {:error, :instance}
+      assert Client.read(:a) == {:ok, 1}
+      assert Client.read(:z) == {:error, :instance}
 
-      {:ok, matches} = Server.match(1)
+      {:ok, matches} = Client.match(1)
       assert Enum.sort(matches) == [:a, :c]
 
-      assert Server.delete(:a) == :ok
-      assert Server.read(:a) == {:error, :instance}
+      assert Client.delete(:a) == :ok
+      assert Client.read(:a) == {:error, :instance}
 
-      assert Server.stop() == :ok
+      assert Client.stop() == :ok
     end
 
     test ":map_db" do
-      :ok = Server.start(:map_db)
-      assert Server.write(:a, 1) == :ok
-      assert Server.write(:b, 2) == :ok
-      assert Server.write(:c, 1) == :ok
+      :ok = Client.start(MyDb.Backends.MapDb)
+      assert Client.write(:a, 1) == :ok
+      assert Client.write(:b, 2) == :ok
+      assert Client.write(:c, 1) == :ok
 
-      assert Server.read(:a) == {:ok, 1}
-      assert Server.read(:z) == {:error, :instance}
+      assert Client.read(:a) == {:ok, 1}
+      assert Client.read(:z) == {:error, :instance}
 
-      {:ok, matches} = Server.match(1)
+      {:ok, matches} = Client.match(1)
       assert Enum.sort(matches) == [:a, :c]
 
-      assert Server.delete(:a) == :ok
-      assert Server.read(:a) == {:error, :instance}
+      assert Client.delete(:a) == :ok
+      assert Client.read(:a) == {:error, :instance}
 
-      assert Server.stop() == :ok
+      assert Client.stop() == :ok
     end
 
     test ":tree_db" do
-      :ok = Server.start(:tree_db)
-      assert Server.write(:a, 1) == :ok
-      assert Server.write(:b, 2) == :ok
-      assert Server.write(:c, 1) == :ok
+      :ok = Client.start(MyDb.Backends.TreeDb)
+      assert Client.write(:a, 1) == :ok
+      assert Client.write(:b, 2) == :ok
+      assert Client.write(:c, 1) == :ok
 
-      assert Server.read(:a) == {:ok, 1}
-      assert Server.read(:z) == {:error, :instance}
+      assert Client.read(:a) == {:ok, 1}
+      assert Client.read(:z) == {:error, :instance}
 
-      {:ok, matches} = Server.match(1)
+      {:ok, matches} = Client.match(1)
       assert Enum.sort(matches) == [:a, :c]
 
-      assert Server.delete(:a) == :ok
-      assert Server.read(:a) == {:error, :instance}
+      assert Client.delete(:a) == :ok
+      assert Client.read(:a) == {:error, :instance}
 
-      assert Server.stop() == :ok
+      assert Client.stop() == :ok
     end
 
     test ":struct_db" do
-      :ok = Server.start(:struct_db)
-      assert Server.write(:a, 1) == :ok
-      assert Server.write(:b, 2) == :ok
-      assert Server.write(:c, 1) == :ok
+      :ok = Client.start(MyDb.Backends.StructDb)
+      assert Client.write(:a, 1) == :ok
+      assert Client.write(:b, 2) == :ok
+      assert Client.write(:c, 1) == :ok
 
-      assert Server.read(:a) == {:ok, 1}
-      assert Server.read(:z) == {:error, :instance}
+      assert Client.read(:a) == {:ok, 1}
+      assert Client.read(:z) == {:error, :instance}
 
-      {:ok, matches} = Server.match(1)
+      {:ok, matches} = Client.match(1)
       assert Enum.sort(matches) == [:a, :c]
 
-      assert Server.delete(:a) == :ok
-      assert Server.read(:a) == {:error, :instance}
+      assert Client.delete(:a) == :ok
+      assert Client.read(:a) == {:error, :instance}
 
-      assert Server.stop() == :ok
+      assert Client.stop() == :ok
     end
 
     test ":ets_db" do
-      :ok = Server.start(:ets_db)
-      assert Server.write(:a, 1) == :ok
-      assert Server.write(:b, 2) == :ok
-      assert Server.write(:c, 1) == :ok
+      :ok = Client.start(MyDb.Backends.EtsDb)
+      assert Client.write(:a, 1) == :ok
+      assert Client.write(:b, 2) == :ok
+      assert Client.write(:c, 1) == :ok
 
-      assert Server.read(:a) == {:ok, 1}
-      assert Server.read(:z) == {:error, :instance}
+      assert Client.read(:a) == {:ok, 1}
+      assert Client.read(:z) == {:error, :instance}
 
-      {:ok, matches} = Server.match(1)
+      {:ok, matches} = Client.match(1)
       assert Enum.sort(matches) == [:a, :c]
 
-      assert Server.delete(:a) == :ok
-      assert Server.read(:a) == {:error, :instance}
+      assert Client.delete(:a) == :ok
+      assert Client.read(:a) == {:error, :instance}
 
-      assert Server.stop() == :ok
+      assert Client.stop() == :ok
     end
   end
 end


### PR DESCRIPTION
Organize it a little more clearly, so the code is run in the caller is clearly distinct from the code being run in the server